### PR TITLE
tests_functional: Update source_url to use the new GitHub repository

### DIFF
--- a/cove/cove_360/tests_functional.py
+++ b/cove/cove_360/tests_functional.py
@@ -164,7 +164,7 @@ def test_explore_360_url_input(server_url, browser, httpserver, source_filename,
         httpserver.serve_content(fp.read())
     if 'CUSTOM_SERVER_URL' in os.environ:
         # Use urls pointing to GitHub if we have a custom (probably non local) server URL
-        source_url = 'https://raw.githubusercontent.com/OpenDataServices/cove/live/cove_360/fixtures/' + source_filename
+        source_url = 'https://raw.githubusercontent.com/ThreeSixtyGiving/dataquality/main/cove/cove_360/fixtures/' + source_filename
     else:
         source_url = httpserver.url + PREFIX_360 + source_filename
 
@@ -431,7 +431,7 @@ def test_error_modal(server_url, browser, httpserver, source_filename):
         httpserver.serve_content(fp.read())
     if 'CUSTOM_SERVER_URL' in os.environ:
         # Use urls pointing to GitHub if we have a custom (probably non local) server URL
-        source_url = 'https://raw.githubusercontent.com/OpenDataServices/cove/live/cove_360/fixtures/' + source_filename
+        source_url = 'https://raw.githubusercontent.com/ThreeSixtyGiving/dataquality/main/cove/cove_360/fixtures/' + source_filename
     else:
         source_url = httpserver.url + '/' + source_filename
 
@@ -479,7 +479,7 @@ def test_check_schema_link_on_result_page(server_url, browser, httpserver, sourc
         httpserver.serve_content(fp.read())
     if 'CUSTOM_SERVER_URL' in os.environ:
         # Use urls pointing to GitHub if we have a custom (probably non local) server URL
-        source_url = 'https://raw.githubusercontent.com/OpenDataServices/cove/live/cove_360/fixtures/' + source_filename
+        source_url = 'https://raw.githubusercontent.com/ThreeSixtyGiving/dataquality/main/cove/cove_360/fixtures/' + source_filename
     else:
         source_url = httpserver.url + '/' + source_filename
 


### PR DESCRIPTION
This fixes tests run with CUSTOM_SERVER_URL, e.g.
https://github.com/OpenDataServices/opendataservices-deploy/actions