### PR TITLE
github: test: Remove Python 3.6

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,9 +6,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        # Python 3.6 is used by the datastore
-        # Python 3.8 is used by the 360 and IATI live cove servers
-        python-version: [ '3.6', '3.8']
+        # Python 3.8 is used by the live cove and datastore servers
+        python-version: [ '3.8']
     steps:
     - uses: actions/checkout@v2
     - name: Setup python


### PR DESCRIPTION
I can't see any record of IATI Cove using this library, so edit comment