### PR TITLE
template: Update logo link to DQT homepage

### DIFF
--- a/cove/cove_360/templates/cove_360/base.html
+++ b/cove/cove_360/templates/cove_360/base.html
@@ -8,7 +8,7 @@
 {% block heading %}
   <div class="row">
     <div class="col-md-5">
-      <a id="360_giving_logo" href="https://www.threesixtygiving.org/">
+      <a id="360_giving_logo" href="{% url 'index' %}">
         <img src="{% static 'dataexplore/360-giving-logo.svg' %}" alt="360Giving Logo" width="270"/>
       </a>
     </div>

--- a/cove/cove_360/tests_functional.py
+++ b/cove/cove_360/tests_functional.py
@@ -373,15 +373,7 @@ def test_index_page_360_links(server_url, browser, link_text, url):
     link = browser.find_element_by_link_text(link_text)
     href = link.get_attribute("href")
     assert url in href
-
-
-def test_index_page_360_logo_link(server_url, browser):
-    browser.get(server_url)
-    link = browser.find_element_by_id('360_giving_logo')
-    href = link.get_attribute('href')
-
-    assert href == 'https://www.threesixtygiving.org/'
-
+    
 
 def test_common_index_elements(server_url, browser):
     browser.get(server_url)


### PR DESCRIPTION
## Summary
Edit homepage logo link to point to DQT homepage, not 360Giving homepage

Fixes: https://github.com/ThreeSixtyGiving/dataquality/issues/59

## Verify
1. Follow the link by selecting the logo in the DQT header 
2. Browser should navigate to https://dataquality.threesixtygiving.org/ (or equivalent DQT homepage depending on environment)