### PR TITLE
lib360dataquality: Remove extra 1 from "Incorrect values" count

### DIFF
--- a/lib360dataquality/cove/threesixtygiving.py
+++ b/lib360dataquality/cove/threesixtygiving.py
@@ -436,10 +436,7 @@ def common_checks_360(
             {
                 "{}_errored".format(test_class_type): extra_checks is None,
                 "{}_checks".format(test_class_type): extra_checks,
-                "{}_checks_count".format(test_class_type): (
-                    len(extra_checks) if extra_checks else 0
-                )
-                + (1 if context["data_only"] else 0),
+                "{}_checks_count".format(test_class_type): len(extra_checks) if extra_checks else 0
             }
         )
 


### PR DESCRIPTION
We were adding an extra 1 for additional fields, from when they used to be grouped under the same section. This should now be removed.

Internal issue: https://opendataservices.plan.io/issues/37832