### PR TITLE
cove: Codelist errors link to the docs site

### DIFF
--- a/cove/cove_360/templates/additional_codelist_values.html
+++ b/cove/cove_360/templates/additional_codelist_values.html
@@ -1,0 +1,32 @@
+{% load i18n %}
+{% load cove_tags %}
+
+<table class="table">
+   <thead>
+     <tr> 
+       <th>{% trans 'Field' %}</th> 
+       <th>{% trans 'Path to Field' %}</th> 
+       <th>{% trans 'Codelist' %}</th> 
+       <th>{% trans 'Additional Values Used' %}</th>
+     </tr>
+   </thead>
+   <tbody>
+   {% for path, detail in additional_codelist_values.items %}
+      <tr>
+        <td>{{detail.field}}</td> <td>{{detail.path}}</td> 
+        <td>
+          <a href="{{detail.codelist_url}}" >{{detail.codelist}}</a>
+          {% if detail.codelist_amend_urls %}
+            ( 
+            {% for symbol, url in detail.codelist_amend_urls %}
+              <a href="{{url|urlencode}}">{{symbol}}</a>
+            {% endfor %}
+            )
+          {% endif %}
+
+        </td> 
+        <td>{{detail.values|join:", "}}</td>
+      </tr>
+   {% endfor %}
+   </tbody>
+</table>

--- a/cove/cove_360/views.py
+++ b/cove/cove_360/views.py
@@ -3,6 +3,7 @@ import csv
 import itertools
 import json
 import logging
+import re
 from decimal import Decimal
 
 from cove.views import explore_data_context, cove_web_input_error
@@ -124,6 +125,14 @@ def explore_360(request, pk, template='cove_360/explore.html'):
             json_data = json.load(fp, parse_float=Decimal)
 
     context = common_checks_360(context, upload_dir, json_data, schema_360)
+
+    # Construct the 360Giving specific urls for codelists in the docs
+    for key in ['additional_closed_codelist_values', 'additional_open_codelist_values']:
+        for path_string, codelist_info in context[key].items():
+            codelist_info['codelist_url'] = (
+                'https://standard.threesixtygiving.org/en/latest/technical/codelists/#' +
+                re.sub(r'([A-Z])', r'-\1', codelist_info['codelist'].split('.')[0]).lower()
+            )
 
     # Experimental to test performance impacts
     # Note False will currently leave the grants table in the UI empty

--- a/cove/cove_project/settings.py
+++ b/cove/cove_project/settings.py
@@ -88,6 +88,10 @@ if getattr(settings, 'RAVEN_CONFIG', None):
     RAVEN_CONFIG = settings.RAVEN_CONFIG
 
 INSTALLED_APPS = (
+    'cove_360',
+    'cove',
+    'cove.input',
+    'bootstrap3',
     'django.contrib.admin',
     'django.contrib.auth',
     'django.contrib.contenttypes',
@@ -95,10 +99,6 @@ INSTALLED_APPS = (
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
-    'bootstrap3',
-    'cove',
-    'cove.input',
-    'cove_360',
 )
 
 WSGI_APPLICATION = 'cove_project.wsgi.application'


### PR DESCRIPTION
https://github.com/ThreeSixtyGiving/dataquality/issues/80

This replaced a now broken link to data pipes.

Also reorders INSTALLED_APPS so that cove_360 templates overwrite lib-cove-web (cove) ones.