### PR TITLE
matomo: Add events for domain & data validation

### DIFF
--- a/cove/cove_360/templates/cove_360/explore.html
+++ b/cove/cove_360/templates/cove_360/explore.html
@@ -58,6 +58,31 @@
         </p>
         {% endif %}
 
+        <script>
+          window.addEventListener('load', function() {
+      
+            let domainValidation, dataValidation, validation;
+      
+            if ('{{ data_status.can_publish }}' === 'True') {
+              domainValidation = "domain-valid"
+            } else {
+              domainValidation = 'domain-invalid'
+            }
+      
+            if ('{{ data_status.passed }}' === 'True') {
+              dataValidation = "data-valid"
+            } else {
+              dataValidation = 'data-invalid'
+            }
+      
+            validation = `${domainValidation}-${dataValidation}`;
+            source = '{{ source_url }}'
+      
+            _paq.push(['trackEvent', 'Status', validation, source]);
+            _paq.push(['trackPageView']);
+          })
+        </script>
+
     </div>
   </div>
   {% endif %}

--- a/cove/cove_360/templates/cove_360/publisher_not_found.html
+++ b/cove/cove_360/templates/cove_360/publisher_not_found.html
@@ -14,4 +14,29 @@
         <p>{% blocktrans %}Please email 360Giving helpdesk via <a href="mailto:support@threesixtygiving.org">support@threesixtygiving.org</a> with the link to the file you want to submit to the Data Registry.{% endblocktrans %}</p>
     </div>
   </div>
+
+  <script>
+    window.addEventListener('load', function() {
+
+      let domainValidation, dataValidation, validation;
+
+      if ('{{ data_status.can_publish }}' === 'True') {
+        domainValidation = "domain-valid"
+      } else {
+        domainValidation = 'domain-invalid'
+      }
+
+      if ('{{ data_status.passed }}' === 'True') {
+        dataValidation = "data-valid"
+      } else {
+        dataValidation = 'data-invalid'
+      }
+
+      validation = domainValidation + '-' + dataValidation;
+      source = '{{ source_url }}'
+
+      _paq.push(['trackEvent', 'Status', validation, source]);
+      _paq.push(['trackPageView']);
+    })
+  </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
+ Add Matomo events for tracking publisher data submission, using the following schema:
  + Event Category: 'Status'
  + Event Action: 'domain-[valid/invalid]-data-[valid/invalid]'
  + Event Name: '[publisher url]'

e.g. `'Status', 'domain-valid-data-invalid', 'example-data-publisher.org'`