### PR TITLE
lib360dataquality: check_field_present: Add IndividualsCodeListsNotPr…

### DIFF
--- a/lib360dataquality/check_field_present.py
+++ b/lib360dataquality/check_field_present.py
@@ -1,4 +1,4 @@
-from lib360dataquality.cove.threesixtygiving import AdditionalTest
+from lib360dataquality.cove.threesixtygiving import AdditionalTest, RECIPIENT_INDIVIDUAL
 from functools import wraps
 
 
@@ -92,3 +92,26 @@ class GrantProgrammeTitleNotPresent(FieldNotPresentBase):
     @exception_to_false
     def check_field(self, grant):
         return grant["grantProgramme"][0]["title"]
+
+
+class IndividualsCodeListsNotPresent(FieldNotPresentBase):
+    field = (
+        "toIndividualsDetails/grantPurpose or toIndividualsDetails/primaryGrantReason"
+    )
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.relevant_grant_type = RECIPIENT_INDIVIDUAL
+
+    def check_field(self, grant):
+        # Not relevant
+        if not grant.get("recipientIndividual"):
+            return True
+
+        details = grant.get("toIndividualsDetails")
+        if details:
+            return (
+                len(details.get("grantPurpose", [])) > 0
+                or len(details.get("primaryGrantReason", "")) > 0
+            )
+        return False

--- a/lib360dataquality/cove/threesixtygiving.py
+++ b/lib360dataquality/cove/threesixtygiving.py
@@ -553,6 +553,9 @@ class AdditionalTest:
         elif self.relevant_grant_type == RECIPIENT_ORGANISATION:
             total = self.aggregates["count"] - self.aggregates["recipient_individuals_count"]
         elif self.relevant_grant_type == RECIPIENT_INDIVIDUAL:
+            # if there are no individuals in this data then reset the count
+            if self.aggregates["recipient_individuals_count"] == 0:
+                self.count = 0
             total = self.aggregates["recipient_individuals_count"]
 
         # Guard against a division by 0


### PR DESCRIPTION
…esent

This checks to see if either the grantPurpose codelist or primaryGrantReason has values.

Add recipient relevant_grant_type mechanism into the check_field_present and make sure that if RECIPIENT_INDIVIDUAL it is not counted when the data has no recipientIndividual data.