### PR TITLE
cove: templates: Copy in and change lib-cove-web input template

### DIFF
--- a/cove/cove_360/templates/cove_360/input.html
+++ b/cove/cove_360/templates/cove_360/input.html
@@ -1,10 +1,90 @@
-{% extends "input.html" %}
+{% extends request.current_app_base_template %}
+{% load bootstrap3 %}
+{% load i18n %}
+
+{# For original input.html see lib-cove-web/cove/templates/input.html #}
 
 {% block precontent %}
 <div class="row">
   <div class="col-md-8">
     <h2>Check your data</h2>
     <p>Upload or provide a link to a file, or paste JSON to check and convert your data and get feedback on whether it is valid 360Giving data.</p>
+  </div>
+</div>
+{% endblock %}
+
+
+{% block content %}
+<div id="loading" style="display: none"> <h3>{% trans "Loading:" %}</h3> <img class="spinner" src="//i1.wp.com/cdnjs.cloudflare.com/ajax/libs/galleriffic/2.0.1/css/loader.gif" alt="spinner" width="30" height="30"> </div>
+<div class="panel-group" id="accordion" role="tablist" aria-multiselectable="true">
+  {% if 'upload' in input_methods %}
+  <div class="panel panel-default">
+    <div class="panel-heading" role="tab" id="headingOne" data-toggle="collapse" data-parent="#accordion" data-target="#collapseOne" aria-expanded="true" aria-controls="collapseOne">
+      <h4 class="panel-title">
+        <a class="accordion-toggle">
+          <span class="glyphicon glyphicon-upload" aria-hidden="true"></span>{% trans "Upload" %}
+        </a>
+      </h4>
+    </div>
+    <div id="collapseOne" class="panel-collapse collapse in" role="tabpanel" aria-labelledby="headingOne">
+      <div class="panel-body">
+        <form method="POST" action="." enctype="multipart/form-data">{% csrf_token %}
+            {% bootstrap_form forms.upload_form %}
+            {% buttons %}
+                <button type="submit" class="btn btn-primary">
+                    {% trans 'Check Data' %}
+                </button>
+            {% endbuttons %}
+        </form>
+      </div>
+    </div>
+  </div>
+  {% endif %}
+  {% if 'url' in input_methods %}
+  <div class="panel panel-default">
+    <div class="panel-heading" role="tab" id="headingTwo" data-toggle="collapse" data-parent="#accordion" data-target="#collapseTwo" aria-expanded="true" aria-controls="collapseTwo">
+      <h4 class="panel-title">
+        <a class="accordion-toggle">
+          <span class="glyphicon glyphicon-link" aria-hidden="true"></span>{% trans "Link" %}
+        </a>
+      </h4>
+    </div>
+    <div id="collapseTwo" class="panel-collapse show-open-if-noscript" role="tabpanel" aria-labelledby="headingTwo">
+      <div class="panel-body">
+        <form method="POST" action="." id="fetchURL">{% csrf_token %}
+            {% bootstrap_form forms.url_form %}
+            {% buttons %}
+                <button type="submit" class="btn btn-primary">
+                    {% trans 'Check Data' %}
+                </button>
+            {% endbuttons %}
+        </form>
+      </div>
+    </div>
+  </div>
+  {% endif %}
+  {% if 'text' in input_methods %}
+  <div class="panel panel-default">
+    <div class="panel-heading" role="tab" id="headingThree" data-toggle="collapse" data-parent="#accordion" data-target="#collapseThree" aria-expanded="true" aria-controls="collapseThree">
+      <h4 class="panel-title">
+        <a class="accordion-toggle">
+          <span class="glyphicon glyphicon-paste" aria-hidden="true"></span>{% trans "Paste" %}
+        </a>
+      </h4>
+    </div>
+    <div id="collapseThree" class="panel-collapse show-open-if-noscript" role="tabpanel" aria-labelledby="headingThree">
+      <div class="panel-body">
+        <form method="POST" action=".">{% csrf_token %}
+            {% bootstrap_form forms.text_form %}
+            {% buttons %}
+                <button type="submit" class="btn btn-primary">
+                    {% trans 'Check Data' %}
+                </button>
+            {% endbuttons %}
+        </form>
+      </div>
+    </div>
+  {% endif %}
   </div>
 </div>
 {% endblock %}
@@ -38,5 +118,22 @@
   </div>
 </div>
 {% endif %}
+{% endblock %}
 
+{% block extrafooterscript %}
+ <script>
+   //If javascript is off all pannels show.
+   //We use this to collapse pannels 2 and 3 if javascript is on.
+  $("#collapseTwo").attr('class', 'panel-collapse collapse');
+  $("#collapseThree").attr('class', 'panel-collapse collapse');
+
+  $('form').submit(function() {
+      $('#loading').css({"display": "block"});
+      $('#accordion').hide();
+  });
+  $(window).unload(function() {
+    $('#loading').css({"display": "none"});
+  })
+
+</script>
 {% endblock %}


### PR DESCRIPTION
We're needing to deviate from lib-cove-web provided template to change the button copy which is causing confusion between checking the data and submitting the data. Further changes away from the default layout are planned so this is partly a stop-gap solution.

Fixes: https://github.com/ThreeSixtyGiving/dataquality/issues/102