### PR TITLE
cove: input: Switch to POST for data file submission form

### DIFF
--- a/cove/cove_360/templates/cove_360/input.html
+++ b/cove/cove_360/templates/cove_360/input.html
@@ -101,7 +101,7 @@
 
 <div class="panel panel-default">
   <div class="panel-body">
-    <form method="GET" action="." id="self-publishing-form">
+    <form method="POST" action="." id="self-publishing-form">
       {% csrf_token %}
       <input type="hidden" name="self_publishing" value="true">
       <div class="form-group">


### PR DESCRIPTION
This allows the CSRF mechanism to work which is required by the next version of lib-cove-web.