### PR TITLE
cove: urls: Add redirect from /submit for forward compatibility

### DIFF
--- a/cove/cove_360/templates/cove_360/input.html
+++ b/cove/cove_360/templates/cove_360/input.html
@@ -93,7 +93,7 @@
 {% if DATA_SUBMISSION_ENABLED %}
 <div class="row">
     <div class="col-md-8">
-      <h2>Submit your data</h2>
+      <h2 id="submit-data-for-publishing">Submit your data</h2>
       <p>Submit your 360Giving data file to the <a href="https://data.threesixtygiving.org/">360Giving Data Registry</a>. Your file will also be checked to make sure you are submitting valid 360Giving data.</p>
 
     </div>

--- a/cove/cove_project/urls.py
+++ b/cove/cove_project/urls.py
@@ -2,6 +2,7 @@ from django.conf.urls import url
 from django.conf.urls.static import static
 from django.conf import settings
 from django.urls import path
+from django.views.generic import RedirectView
 
 from cove.urls import urlpatterns, handler500  # noqa: F401
 
@@ -15,7 +16,9 @@ urlpatterns += [
     path("api/results/<uuid:id>", cove_360.api.ResultsApiView.as_view(), name="api-results"),
     url(r'^xhr_results_ready/(.+)$', cove_360.views.results_ready, name='xhr_results_ready'),
     url(r'^common_errors', cove_360.views.common_errors, name='common_errors'),
-    url(r'^additional_checks', cove_360.views.additional_checks, name='additional_checks')
+    url(r'^additional_checks', cove_360.views.additional_checks, name='additional_checks'),
+    # In preperation for new DQT version forward compatibility
+    url(r'^submit', RedirectView.as_view(url="/#submit-data-for-publishing", permanent=False), name='submit-temp-tional_checks'),
 ]
 
 urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/cove/cove_project/urls.py
+++ b/cove/cove_project/urls.py
@@ -18,7 +18,7 @@ urlpatterns += [
     url(r'^common_errors', cove_360.views.common_errors, name='common_errors'),
     url(r'^additional_checks', cove_360.views.additional_checks, name='additional_checks'),
     # In preperation for new DQT version forward compatibility
-    url(r'^submit', RedirectView.as_view(url="/#submit-data-for-publishing", permanent=False), name='submit-temp-tional_checks'),
+    url(r'^submit', RedirectView.as_view(url="/#submit-data-for-publishing", permanent=False), name='submit-temp'),
 ]
 
 urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)


### PR DESCRIPTION
This soon will be a working URL. It is intended to be added to a site before the launch of new DQT.