### PR TITLE
lib360dataquality: Skip BeneficiaryButNotRecipientGeoData for grants ind

### DIFF
--- a/lib360dataquality/cove/threesixtygiving.py
+++ b/lib360dataquality/cove/threesixtygiving.py
@@ -1876,6 +1876,9 @@ class BeneficiaryButNotRecipientGeoData(AdditionalTest):
         self.relevant_grant_type = TestRelevance.RECIPIENT_ORGANISATION
 
     def process(self, grant, path_prefix):
+        if grant.get("recipientIndividual"):
+            return
+
         beneficiary_locations = grant.get("beneficiaryLocation", [])
         if (
             len(beneficiary_locations) > 0


### PR DESCRIPTION
Skip BeneficiaryButNotRecipientGeoData for grants to individuals as we don't have a recipient organisation to apply this to.