### PR TITLE
lib360dataquality: PlannedDurationNotPresent check None instead of tr…

### DIFF
--- a/lib360dataquality/check_field_present.py
+++ b/lib360dataquality/check_field_present.py
@@ -108,7 +108,7 @@ class PlannedDurationNotPresent(FieldNotPresentBase):
 
     @exception_to_false
     def check_field(self, grant):
-        return (grant["plannedDates"][0].get("duration") or (grant["plannedDates"][0].get("startDate") and grant["plannedDates"][0].get("endDate")))
+        return (grant["plannedDates"][0].get("duration") is not None or (grant["plannedDates"][0].get("startDate") and grant["plannedDates"][0].get("endDate")))
 
     def process(self, grant, path_prefix):
         super().process(grant, path_prefix)


### PR DESCRIPTION
…uthy

Ensure that a duration of 0 isn't evaluated to false. Guidance that 0 is an acceptable value.

Fixes: https://github.com/ThreeSixtyGiving/dataquality/issues/166